### PR TITLE
use /var/tmp in favor of /tmp

### DIFF
--- a/mods-available/git/functions/git-import
+++ b/mods-available/git/functions/git-import
@@ -21,7 +21,7 @@ fi
 
 # Make unique temporary directory
 # https://unix.stackexchange.com/a/84980/39419
-temp=$(mktemp -d 2>/dev/null || mktemp -d -t 'temp')
+temp=$(mktemp -p /var/tmp -d 2>/dev/null || mktemp -d -t 'temp')
 
 # Make patches
 (


### PR DESCRIPTION
Writing to /tmp on many systems these days is a ram filesystem and using this location could cause system issues if it is a large repository.