### PR TITLE
don't use *.patch

### DIFF
--- a/mods-available/git/functions/git-import
+++ b/mods-available/git/functions/git-import
@@ -38,7 +38,13 @@ git-import () {
   )
 
   # Apply patches, try aborting on error but ignore abort errors
-  git am "$temp"/*.patch || git am --abort || :
+  for i in "$temp"/*.patch
+  do
+      if test -f "$i"
+      then
+          git am $i || git am --abort || :
+      fi
+  done
 
   # Delete temporary directory
   rm -rf "$temp"


### PR DESCRIPTION
If you are moving a directory or file with a large history you will easily exceed the commandline number of arguments/length.  This change will apply patches one at a time and avoid the error with *.patch